### PR TITLE
Update compile script to support authenticated Maxmind downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,22 @@ The GeoLite2 databases are distributed under the Creative Commons Attribution-Sh
     This product includes GeoLite2 data created by MaxMind, available from
     <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
 
+As of 30-Dev-2019, Maxmind has withdrawn unauthenticated downloads of their free GeoLite2 databases. Read more [here](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/).
+
+From Jan-2020 users need a Maxmind account, and a valid license key. This buildpack uses the "direct download" method described in the Maxmind developer documentation (https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads).
+
 ### Heroku
 
 ```sh
 $ heroku buildpacks:add https://github.com/danstiner/heroku-buildpack-geoip-geolite2.git
 ```
 
+In order to download the Maxmind databases, you will need a valid Maxmind license (register with Maxmind and click on "My License Key" in the left-hand menu). You must add this key as an environment variable (setting) called `MAXMIND_LICENSE_KEY`.
+
 ### Django GeoIP2
 
 Add to your `settings.py` file:
+
 ```python
 GEOIP_PATH=os.environ['GEOIP_GEOLITE2_PATH']
 GEOIP_CITY=os.environ['GEOIP_GEOLITE2_CITY_FILENAME']

--- a/bin/compile
+++ b/bin/compile
@@ -42,10 +42,10 @@ mkdir -p "$LIBMAXMINDDB_CACHE_DIST_DIR"
 echo "       Downloading GeoLite2 City and Country data"
 
 # see https://dev.maxmind.com/geoip/geoipupdate/ (Direct Downloads version)
-wget --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
+wget --quiet --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
-wget --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
+wget --quiet --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
 echo "       Unzipping GeoLite2 City and Country data"

--- a/bin/compile
+++ b/bin/compile
@@ -2,9 +2,21 @@
 
 set -e
 
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
+
+# see https://devcenter.heroku.com/articles/buildpack-api - during compilation
+# app env vars exist only as files within the ENV_VAR directory
+if [[ -s "$ENV_DIR/MAXMIND_LICENSE_KEY" ]]
+then
+    echo "-----> MAXMIND_LICENSE_KEY set - proceeding with installation"
+    MAXMIND_LICENSE_KEY=$(cat $ENV_DIR/MAXMIND_LICENSE_KEY)
+else
+    echo "-----> MAXMIND_LICENSE_KEY not set - ignoring installation"
+    exit 0
+fi
 
 LIBMAXMINDDB_VERSION=1.2.1
 GEOLITE2_CITY_FILENAME="GeoLite2-City.mmdb"
@@ -29,8 +41,14 @@ mkdir -p "$LIBMAXMINDDB_CACHE_DIST_DIR"
 
 echo "       Downloading GeoLite2 City and Country data"
 
-wget -Nq -P "$GEOIP_CACHE_DIR" "https://geolite.maxmind.com/download/geoip/database/$GEOLITE2_CITY_TARBALL_FILENAME" 
-wget -Nq -P "$GEOIP_CACHE_DIR" "https://geolite.maxmind.com/download/geoip/database/$GEOLITE2_COUNTRY_TARBALL_FILENAME"
+# see https://dev.maxmind.com/geoip/geoipupdate/ (Direct Downloads version)
+wget --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
+     "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
+
+wget --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
+     "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
+
+echo "       Unzipping GeoLite2 City and Country data"
 
 tar -xvf "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" --directory "$BUILD_DIST_SHARE_DIR" --no-anchored --strip-components=1 "$GEOLITE2_CITY_FILENAME"
 tar -xvf "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" --directory "$BUILD_DIST_SHARE_DIR" --no-anchored --strip-components=1 "$GEOLITE2_COUNTRY_FILENAME"
@@ -51,7 +69,7 @@ else
     tar -xf "$WORK_DIR/libmaxminddb-$LIBMAXMINDDB_VERSION.tar.gz" --directory "$WORK_DIR" --strip-components=1
 
     echo "       Building libmaxminddb-$LIBMAXMINDDB_VERSION"
-    
+
     pushd "$WORK_DIR" > /dev/null
     ./configure --quiet --prefix "$LIBMAXMINDDB_CACHE_DIST_DIR"
     make >/dev/null || make


### PR DESCRIPTION
I've updated the `wget` call to use the new URL, and to read in the license key from an env var. If the env var doesn't exist the script exits (with return code of 0).

License key exists: 

```
-----> GeoLite2 app detected
-----> MAXMIND_LICENSE_KEY set - proceeding with installation
-----> Installing GeoLite2 data and libmaxminddb from https://www.maxmind.com
       Downloading GeoLite2 City and Country data
...
```

License key does not exist:

```
-----> GeoLite2 app detected
-----> MAXMIND_LICENSE_KEY not set - ignoring installation
```
