### PR TITLE
Add .geoip/include to C_INCLUDE_PATH and .geoip/lib to LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,7 @@ export GEOIP_GEOLITE2_CITY_FILENAME="$GEOLITE2_CITY_FILENAME"
 export GEOIP_GEOLITE2_COUNTRY_FILENAME="$GEOLITE2_COUNTRY_FILENAME"
 export LD_LIBRARY_PATH="\$HOME/.geoip/lib:\$LD_LIBRARY_PATH"
 export PATH="\$HOME/.geoip/bin:\$PATH"
+export C_INCLUDE_PATH="\$HOME/.geoip/include:\$C_INCLUDE_PATH"
 EOF
 
 cp $BUILD_DIR/.profile.d/geoip.sh ./export

--- a/bin/compile
+++ b/bin/compile
@@ -88,13 +88,13 @@ echo "       Set environment variables GEOIP_GEOLITE2_PATH, GEOIP_GEOLITE2_CITY_
 
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/geoip.sh
-export GEOIP_GEOLITE2_PATH="\$HOME/.geoip/share/"
+export GEOIP_GEOLITE2_PATH="$BUILD_DIST_DIR/share/"
 export GEOIP_GEOLITE2_CITY_FILENAME="$GEOLITE2_CITY_FILENAME"
 export GEOIP_GEOLITE2_COUNTRY_FILENAME="$GEOLITE2_COUNTRY_FILENAME"
-export LIBRARY_PATH="\$HOME/.geoip/lib:\$LIBRARY_PATH"
-export LD_LIBRARY_PATH="\$HOME/.geoip/lib:\$LD_LIBRARY_PATH"
-export PATH="\$HOME/.geoip/bin:\$PATH"
-export C_INCLUDE_PATH="\$HOME/.geoip/include:\$C_INCLUDE_PATH"
+export LIBRARY_PATH="$BUILD_DIST_DIR/lib:\$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$BUILD_DIST_DIR/lib:\$LD_LIBRARY_PATH"
+export PATH="$BUILD_DIST_DIR/bin:\$PATH"
+export C_INCLUDE_PATH="$BUILD_DIST_DIR/include:\$C_INCLUDE_PATH"
 EOF
 
 cp $BUILD_DIR/.profile.d/geoip.sh ./export

--- a/bin/compile
+++ b/bin/compile
@@ -91,6 +91,7 @@ cat <<EOF >$BUILD_DIR/.profile.d/geoip.sh
 export GEOIP_GEOLITE2_PATH="\$HOME/.geoip/share/"
 export GEOIP_GEOLITE2_CITY_FILENAME="$GEOLITE2_CITY_FILENAME"
 export GEOIP_GEOLITE2_COUNTRY_FILENAME="$GEOLITE2_COUNTRY_FILENAME"
+export LIBRARY_PATH="\$HOME/.geoip/lib:\$LIBRARY_PATH"
 export LD_LIBRARY_PATH="\$HOME/.geoip/lib:\$LD_LIBRARY_PATH"
 export PATH="\$HOME/.geoip/bin:\$PATH"
 export C_INCLUDE_PATH="\$HOME/.geoip/include:\$C_INCLUDE_PATH"


### PR DESCRIPTION
These were required for me to build the Ruby library hive_geoip2 on heroku.
https://github.com/desuwa/hive_geoip2

Absent the former I get:
```
current directory:
       /app/vendor/bundle/ruby/2.7.0/gems/hive_geoip2-0.1.2/ext/hive_geoip2
       make "DESTDIR="
       compiling hive_geoip2.c
       hive_geoip2.c:6:10: fatal error: maxminddb.h: No such file or directory
        #include "maxminddb.h"
                 ^~~~~~~~~~~~~
       compilation terminated.
       Makefile:244: recipe for target 'hive_geoip2.o' failed
```

Absent the latter I get:
```
linking shared-object hive_geoip2.so
       /usr/bin/ld: cannot find -lmaxminddb
       collect2: error: ld returned 1 exit status
       Makefile:260: recipe for target 'hive_geoip2.so' failed
```